### PR TITLE
Fix implementation of `rotate` in CSS Transform Module Level 2 Specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ module.exports = postcss.plugin('postcss-transform-shortcut', function (opts) {
 		translate: ['0px', '0px', '0px']
 	};
 
-	var splice = Array.prototype.splice,
-			slice = Array.prototype.slice;
+	var splice = Array.prototype.splice;
+	var slice = Array.prototype.slice;
 
 	return function (css) {
 		css.walkRules(function (rule) {


### PR DESCRIPTION
## `rotate`

According to #3,

``` css
.foo {
    rotate: 100deg;
}
.bar {
   rotate: 100deg 0 0 1;
}
```

is now transformed to 

``` css
.foo {
    transform: rotate(100deg);
}
.bar {
    transform: rotate3d(0, 0, 1, 100deg);
}
```
## 3D transforms change

Use 3D transforms only when necessary

``` css
.foo {
    translate: 1px 2px 2px;
    rotate: 100deg;
}
```

is now transformed to 

``` css
.foo {
    transform: translate3d(1px, 2px, 2px) rotate(100deg);
}
```

Also fixed #4.
